### PR TITLE
add protection for create crash

### DIFF
--- a/pkg/generic/registry/create.go
+++ b/pkg/generic/registry/create.go
@@ -21,6 +21,9 @@ func (r *Store) Create(ctx context.Context, obj runtime.Object, createValidation
 	log := log.FromContext(ctx)
 	log.Debug("create")
 
+	if r.CreateStrategy == nil {
+		return nil, apierrors.NewMethodNotSupported(r.DefaultQualifiedResource, "creaate")
+	}
 	if err := r.CreateStrategy.BeginCreate(ctx); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
{"time":"2026-04-28T08:22:53.491994813Z","level":"INFO","message":"strategy","logger":"sdc-api-server-logger","data":{"op":"Update Status Old","key":{"Namespace":"default","Name":"intent1-sros"},"kind":"","resourceVersion":"7","generation":7,"managedFields":3,"finalizers":["configset.config.sdcio.dev/finalizer"]}}
E0428 08:22:53.502624       1 runtime.go:140] "Observed a panic" panic=<
    runtime error: invalid memory address or nil pointer dereference
    goroutine 4651 [running]:
    k8s.io/apiserver/pkg/endpoints/handlers/finisher.finishRequest.func1.1()
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/handlers/finisher/finisher.go:105 +0xad
    panic({0x3453c60?, 0x60e9750?})
        /opt/hostedtoolcache/go/1.25.0/x64/src/runtime/panic.go:783 +0x132
    github.com/henderiw/apiserver-store/pkg/generic/registry.(*Store).Create(0xc0064b82c0, {0x4098748, 0xc00a24f920}, {0x4078c38, 0xc00a1edb00}, 0xc009f45d10, 0xc00a453e28)
        /home/runner/go/pkg/mod/github.com/henderiw/apiserver-store@v0.0.4/pkg/generic/registry/create.go:24 +0x241
    github.com/henderiw/apiserver-store/pkg/generic/registry.(*Store).Update(0xc0064b82c0, {0x4098748, 0xc00a24f7a0}, {0xc009a9b53e, 0xc}, {0x407a1f0, 0xc00a24f890}, 0xc009f45d10, 0xc00a1e5940, 0x1, ...)
        /home/runner/go/pkg/mod/github.com/henderiw/apiserver-store@v0.0.4/pkg/generic/registry/update.go:63 +0x732
    k8s.io/apiserver/pkg/endpoints/handlers.(*patcher).patchResource.func2()
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/handlers/patch.go:704 +0xa7
    k8s.io/apiserver/pkg/endpoints/handlers.(*patcher).patchResource.func3()
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/handlers/patch.go:710 +0x35
    k8s.io/apiserver/pkg/endpoints/handlers/finisher.finishRequest.func1()
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/handlers/finisher/finisher.go:117 +0x75
    created by k8s.io/apiserver/pkg/endpoints/handlers/finisher.finishRequest in goroutine 4650
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/handlers/finisher/finisher.go:92 +0xc8
   
    goroutine 4650 [running]:
    k8s.io/apiserver/pkg/server/filters.(*timeoutHandler).ServeHTTP.func1.1()
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/server/filters/timeout.go:110 +0xb0
    panic({0x324e760?, 0xc009597d70?})
        /opt/hostedtoolcache/go/1.25.0/x64/src/runtime/panic.go:783 +0x132
    k8s.io/apiserver/pkg/endpoints/handlers/finisher.(*result).Return(0xc00d4650e8?)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/handlers/finisher/finisher.go:53 +0xad
    k8s.io/apiserver/pkg/endpoints/handlers/finisher.finishRequest({0x4098748, 0xc00a24f7a0}, 0xc00a1fc6a0, 0x45d964b800, 0x3c68cc8)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/handlers/finisher/finisher.go:126 +0x247
    k8s.io/apiserver/pkg/endpoints/handlers/finisher.FinishRequest(...)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/handlers/finisher/finisher.go:84
    k8s.io/apiserver/pkg/endpoints/handlers.(*patcher).patchResource(0xc00a1881e0, {0x4098748, 0xc00a24f7a0}, 0xc006666340)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/handlers/patch.go:708 +0xa70
    k8s.io/apiserver/pkg/endpoints/handlers.PatchResource.func1({0x408e790, 0xc00a1fc5e0}, 0xc00a27c780)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/handlers/patch.go:247 +0x27ff
    k8s.io/apiserver/pkg/endpoints.(*APIInstaller).registerResourceHandlers.restfulPatchResource.func12(0xc00a1fc5c0, 0xc00a1e78f0)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/installer.go:1332 +0x62
    k8s.io/apiserver/pkg/endpoints.(*APIInstaller).registerResourceHandlers.InstrumentRouteFunc.func13(0xc00a1fc5c0, 0xc00a1e78f0)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/metrics/metrics.go:645 +0x1c8
    github.com/emicklei/go-restful/v3.(*Container).dispatch(0xc0063d4630, {0x40957a0, 0xc00a1e5680}, 0xc00a27c780)
        /home/runner/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.12.2/container.go:299 +0x9b7
    github.com/emicklei/go-restful/v3.(*Container).Dispatch(...)
        /home/runner/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.12.2/container.go:204
    k8s.io/apiserver/pkg/server.director.ServeHTTP({{0x3ab524d?, 0x2308a1e?}, 0xc0063d4630?, 0xc000417f10?}, {0x40957a0, 0xc00a1e5680}, 0xc00a27c780)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/server/handler.go:145 +0x588
    k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.TrackCompleted.trackCompleted.func22({0x40957a0, 0xc00a1e5680}, 0xc00a27c780)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filterlatency/filterlatency.go:108 +0x138
    net/http.HandlerFunc.ServeHTTP(0x4098748?, {0x40957a0?, 0xc00a1e5680?}, 0x4?)
        /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
    k8s.io/apiserver/pkg/endpoints/filters.withAuthorization.func1({0x40957a0, 0xc00a1e5680}, 0xc00a27c780)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filters/authorization.go:84 +0x625
    net/http.HandlerFunc.ServeHTTP(0x0?, {0x40957a0?, 0xc00a1e5680?}, 0x3ab5976?)
        /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
    k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1({0x40957a0, 0xc00a1e5680}, 0xc00a27c640)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filterlatency/filterlatency.go:93 +0x3f4
    net/http.HandlerFunc.ServeHTTP(0x1c3442f?, {0x40957a0?, 0xc00a1e5680?}, 0x4055a58?)
        /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
    k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.TrackCompleted.trackCompleted.func23({0x40957a0, 0xc00a1e5680}, 0xc00a27c640)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filterlatency/filterlatency.go:108 +0x138
    net/http.HandlerFunc.ServeHTTP(0xc00a1e5780?, {0x40957a0?, 0xc00a1e5680?}, 0x1de8070?)
        /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
    k8s.io/apiserver/pkg/server/filters.(*priorityAndFairnessHandler).Handle.func10()
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/server/filters/priority-and-fairness.go:298 +0xd2
    k8s.io/apiserver/pkg/util/flowcontrol.(*configController).Handle.func2()
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/util/flowcontrol/apf_filter.go:192 +0x21d
    k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset.(*request).Finish.func1(0xc00a1ea4b0?, 0x70?, 0x393a4e0?)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go:391 +0x47
    k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset.(*request).Finish(0xc00a1ea4b0, 0xc00a1e7880)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go:392 +0x39
    k8s.io/apiserver/pkg/util/flowcontrol.(*configController).Handle(0xc005e2e780, {0x40987f0, 0xc00a1e7500}, {0xc00a197520, {0x4099090, 0xc00a1e55c0}}, 0x38a1de0?, 0xc00d466a38?, 0x22ee8b7?, 0xc00a1e5740)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/util/flowcontrol/apf_filter.go:179 +0x76b
    k8s.io/apiserver/pkg/server/filters.(*priorityAndFairnessHandler).Handle.func11(0xc0006bcaa0, {0x4098748?, 0xc00a24f4d0?}, {0xc00a197520?, {0x4099090?, 0xc00a1e55c0?}}, 0xc00a1fc560, 0xc00a24f500, 0xc00a1e9a60, 0xc00a1e5740)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/server/filters/priority-and-fairness.go:304 +0xea
    k8s.io/apiserver/pkg/server/filters.(*priorityAndFairnessHandler).Handle(0xc0006bcaa0, {0x40957a0, 0xc00a1e5680}, 0xc00a27c640)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/server/filters/priority-and-fairness.go:305 +0x9f6
    net/http.HandlerFunc.ServeHTTP(0x0?, {0x40957a0?, 0xc00a1e5680?}, 0x3ac6634?)
        /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
    k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1({0x40957a0, 0xc00a1e5680}, 0xc00a27c500)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filterlatency/filterlatency.go:93 +0x3f4
    net/http.HandlerFunc.ServeHTTP(0x1c3442f?, {0x40957a0?, 0xc00a1e5680?}, 0x4055a58?)
        /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
    k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.TrackCompleted.trackCompleted.func24({0x40957a0, 0xc00a1e5680}, 0xc00a27c500)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filterlatency/filterlatency.go:108 +0x138
    net/http.HandlerFunc.ServeHTTP(0xc00a24f140?, {0x40957a0?, 0xc00a1e5680?}, 0xc00a24f320?)
        /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
    k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithImpersonation.func4({0x40957a0, 0xc00a1e5680}, 0xc00a27c500)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filters/impersonation/impersonation.go:51 +0x1b0
    net/http.HandlerFunc.ServeHTTP(0x0?, {0x40957a0?, 0xc00a1e5680?}, 0x3ab5983?)
        /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
    k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1({0x40957a0, 0xc00a1e5680}, 0xc00a27c3c0)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filterlatency/filterlatency.go:93 +0x3f4
    net/http.HandlerFunc.ServeHTTP(0x1c3442f?, {0x40957a0?, 0xc00a1e5680?}, 0x4055a58?)
        /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
    k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.TrackCompleted.trackCompleted.func25({0x40957a0, 0xc00a1e5680}, 0xc00a27c3c0)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filterlatency/filterlatency.go:108 +0x138
    net/http.HandlerFunc.ServeHTTP(0x465d91?, {0x40957a0?, 0xc00a1e5680?}, 0x3aa54a9?)
        /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
    k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1({0x40957a0, 0xc00a1e5680}, 0xc00a27c280)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filterlatency/filterlatency.go:93 +0x3f4
    net/http.HandlerFunc.ServeHTTP(0x4098748?, {0x40957a0?, 0xc00a1e5680?}, 0x4055a58?)
        /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
    k8s.io/apiserver/pkg/endpoints/filters.WithTracing.func2({0x40957a0, 0xc00a1e5680}, 0xc00a27c140)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filters/traces.go:62 +0x597
    net/http.HandlerFunc.ServeHTTP(0x4098748?, {0x40957a0?, 0xc00a1e5680?}, 0x4055a58?)
        /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
    go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.(*middleware).serveHTTP(0xc0004fbb00, {0x408e790, 0xc00a1fc4a0}, 0xc00a279e00, {0x4066b40, 0xc006079290})
        /home/runner/go/pkg/mod/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.64.0/handler.go:178 +0x12c3
    go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.NewMiddleware.func1.1({0x408e790?, 0xc00a1fc4a0?}, 0x17e0f?)
        /home/runner/go/pkg/mod/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.64.0/handler.go:66 +0x35
    net/http.HandlerFunc.ServeHTTP(0x1c3442f?, {0x408e790?, 0xc00a1fc4a0?}, 0x4055a58?)
        /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
    k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.TrackCompleted.trackCompleted.func27({0x408e790, 0xc00a1fc4a0}, 0xc00a279e00)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filterlatency/filterlatency.go:108 +0x138
    net/http.HandlerFunc.ServeHTTP(0x4098748?, {0x408e790?, 0xc00a1fc4a0?}, 0x404e8a0?)
        /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
    k8s.io/apiserver/pkg/endpoints/filters.withAuthentication.func1({0x408e790, 0xc00a1fc4a0}, 0xc00a279e00)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filters/authentication.go:123 +0x87f
    net/http.HandlerFunc.ServeHTTP(0x4098748?, {0x408e790?, 0xc00a1fc4a0?}, 0x4055a58?)
        /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
    k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1({0x408e790, 0xc00a1fc4a0}, 0xc00a279b80)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filterlatency/filterlatency.go:93 +0x3f4
    net/http.HandlerFunc.ServeHTTP(0xc00a279900?, {0x408e790?, 0xc00a1fc4a0?}, 0xc009f45b80?)
        /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
    k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithWarningRecorder.func11({0x408e790, 0xc00a1fc4a0}, 0xc00a279900)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filters/warning.go:35 +0xb9
    net/http.HandlerFunc.ServeHTTP(0xc007551c70?, {0x408e790?, 0xc00a1fc4a0?}, 0xc00c8cefd0?)
        /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
    k8s.io/apiserver/pkg/server/filters.(*timeoutHandler).ServeHTTP.func1()
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/server/filters/timeout.go:115 +0x5b
    created by k8s.io/apiserver/pkg/server/filters.(*timeoutHandler).ServeHTTP in goroutine 4649
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/server/filters/timeout.go:101 +0x198
 > stacktrace=<
    goroutine 4649 [running]:
    k8s.io/apimachinery/pkg/util/runtime.logPanic({0x4098710, 0x61746a0}, {0x324e760, 0xc009597da0})
        /home/runner/go/pkg/mod/k8s.io/apimachinery@v0.35.3/pkg/util/runtime/runtime.go:132 +0xbc
    k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x4098710, 0x61746a0}, {0x324e760, 0xc009597da0}, {0xc007cb93b0, 0x1, 0x4c1931?})
        /home/runner/go/pkg/mod/k8s.io/apimachinery@v0.35.3/pkg/util/runtime/runtime.go:107 +0x116
    k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0xc007cb93f8, 0x1, 0xc005fe7340?})
        /home/runner/go/pkg/mod/k8s.io/apimachinery@v0.35.3/pkg/util/runtime/runtime.go:64 +0x17b
    panic({0x324e760?, 0xc009597da0?})
        /opt/hostedtoolcache/go/1.25.0/x64/src/runtime/panic.go:783 +0x132
    k8s.io/apiserver/pkg/server/filters.(*timeoutHandler).ServeHTTP(0xc006079368, {0x408e790, 0xc00a1fc440}, 0xdf8475800?)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/server/filters/timeout.go:121 +0x32f
    k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestDeadline.withRequestDeadline.func28({0x408e790, 0xc00a1fc440}, 0xc00a279680)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filters/request_deadline.go:100 +0x234
    net/http.HandlerFunc.ServeHTTP(0x4098748?, {0x408e790?, 0xc00a1fc440?}, 0x10?)
        /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
    k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithWaitGroup.withWaitGroup.func29({0x408e790, 0xc00a1fc440}, 0xc00a279680)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/server/filters/waitgroup.go:86 +0x17d
    net/http.HandlerFunc.ServeHTTP(0xc00a24edb0?, {0x408e790?, 0xc00a1fc440?}, 0x3ac00b1?)
        /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
    k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithCacheControl.func14({0x408e790, 0xc00a1fc440}, 0xc00a279680)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filters/cachecontrol.go:31 +0xa7
    net/http.HandlerFunc.ServeHTTP(0x7f16d764a5c0?, {0x408e790?, 0xc00a1fc440?}, 0xc00a1fc440?)
        /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
    k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithHTTPLogging.WithLogging.withLogging.func35({0x408e790, 0xc00a1fc440}, 0xc00a279680)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/server/httplog/httplog.go:112 +0x94
    net/http.HandlerFunc.ServeHTTP(0x4099100?, {0x408e790?, 0xc00a1fc440?}, 0xc005d16960?)
        /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
    k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithLatencyTrackers.func16({0x408d450, 0xc000013790}, 0xc00a279540)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filters/webhook_duration.go:56 +0x143
    net/http.HandlerFunc.ServeHTTP(0xc00a279400?, {0x408d450?, 0xc000013790?}, 0x130?)
        /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
    k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x408d450, 0xc000013790}, 0xc00a279400)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filters/requestinfo.go:39 +0x119
    net/http.HandlerFunc.ServeHTTP(0xc00a2792c0?, {0x408d450?, 0xc000013790?}, 0x19903c90bc?)
        /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
    k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x408d450, 0xc000013790}, 0xc00a2792c0)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filters/request_received_time.go:38 +0xaf
    net/http.HandlerFunc.ServeHTTP(0xc000100008?, {0x408d450?, 0xc000013790?}, 0x47e8a5?)
        /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
    k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x408d450?, 0xc000013790?}, 0xc00a2792c0?)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd5
    net/http.HandlerFunc.ServeHTTP(0x0?, {0x408d450?, 0xc000013790?}, 0x8?)
        /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
    k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x408d450, 0xc000013790}, 0xc00a2792c0)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/server/filters/wrap.go:73 +0xdc
    net/http.HandlerFunc.ServeHTTP(0xc00a24edb0?, {0x408d450?, 0xc000013790?}, 0xc00a8ea5d0?)
        /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
    k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x408d450, 0xc000013790}, 0xc00a279180)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filters/audit_init.go:63 +0x12d
    net/http.HandlerFunc.ServeHTTP(0x0?, {0x408d450?, 0xc000013790?}, 0xc007e14090?)
        /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
    k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x6151040?, {0x408d450?, 0xc000013790?}, 0xc0000abf08?)
        /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/server/handler.go:188 +0x25
    net/http.serverHandler.ServeHTTP({0xc0007deda0?}, {0x408d450?, 0xc000013790?}, 0xc0000abea0?)
        /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:3340 +0x8e
    net/http.initALPNRequest.ServeHTTP({{0x4098748?, 0xc007dda390?}, 0xc007de0008?, {0xc007ae4f00?}}, {0x408d450, 0xc000013790}, 0xc00a279180)
        /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:4013 +0x231
    golang.org/x/net/http2.(*serverConn).runHandler(0x941388?, 0xc00a1ed080?, 0x0?, 0xc00a214ea0?)
        /home/runner/go/pkg/mod/golang.org/x/net@v0.49.0/http2/server.go:2424 +0x9d
    created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 541
        /home/runner/go/pkg/mod/golang.org/x/net@v0.49.0/http2/server.go:2359 +0x21f
 >
E0428 08:22:53.502686       1 wrap.go:57] "apiserver panic'd" method="PATCH" URI="/apis/config.sdcio.dev/v1alpha1/namespaces/default/configsets/intent1-sros/status?fieldManager=ConfigSetController" auditID="ec2679e9-df97-41ff-98ac-0f8c424dd795"
http2: panic serving 10.244.0.1:31646: runtime error: invalid memory address or nil pointer dereference
goroutine 4651 [running]:
k8s.io/apiserver/pkg/endpoints/handlers/finisher.finishRequest.func1.1()
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/handlers/finisher/finisher.go:105 +0xad
panic({0x3453c60?, 0x60e9750?})
    /opt/hostedtoolcache/go/1.25.0/x64/src/runtime/panic.go:783 +0x132
github.com/henderiw/apiserver-store/pkg/generic/registry.(*Store).Create(0xc0064b82c0, {0x4098748, 0xc00a24f920}, {0x4078c38, 0xc00a1edb00}, 0xc009f45d10, 0xc00a453e28)
    /home/runner/go/pkg/mod/github.com/henderiw/apiserver-store@v0.0.4/pkg/generic/registry/create.go:24 +0x241
github.com/henderiw/apiserver-store/pkg/generic/registry.(*Store).Update(0xc0064b82c0, {0x4098748, 0xc00a24f7a0}, {0xc009a9b53e, 0xc}, {0x407a1f0, 0xc00a24f890}, 0xc009f45d10, 0xc00a1e5940, 0x1, ...)
    /home/runner/go/pkg/mod/github.com/henderiw/apiserver-store@v0.0.4/pkg/generic/registry/update.go:63 +0x732
k8s.io/apiserver/pkg/endpoints/handlers.(*patcher).patchResource.func2()
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/handlers/patch.go:704 +0xa7
k8s.io/apiserver/pkg/endpoints/handlers.(*patcher).patchResource.func3()
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/handlers/patch.go:710 +0x35
k8s.io/apiserver/pkg/endpoints/handlers/finisher.finishRequest.func1()
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/handlers/finisher/finisher.go:117 +0x75
created by k8s.io/apiserver/pkg/endpoints/handlers/finisher.finishRequest in goroutine 4650
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/handlers/finisher/finisher.go:92 +0xc8
 
goroutine 4650 [running]:
k8s.io/apiserver/pkg/server/filters.(*timeoutHandler).ServeHTTP.func1.1()
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/server/filters/timeout.go:110 +0xb0
panic({0x324e760?, 0xc009597d70?})
    /opt/hostedtoolcache/go/1.25.0/x64/src/runtime/panic.go:783 +0x132
k8s.io/apiserver/pkg/endpoints/handlers/finisher.(*result).Return(0xc00d4650e8?)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/handlers/finisher/finisher.go:53 +0xad
k8s.io/apiserver/pkg/endpoints/handlers/finisher.finishRequest({0x4098748, 0xc00a24f7a0}, 0xc00a1fc6a0, 0x45d964b800, 0x3c68cc8)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/handlers/finisher/finisher.go:126 +0x247
k8s.io/apiserver/pkg/endpoints/handlers/finisher.FinishRequest(...)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/handlers/finisher/finisher.go:84
k8s.io/apiserver/pkg/endpoints/handlers.(*patcher).patchResource(0xc00a1881e0, {0x4098748, 0xc00a24f7a0}, 0xc006666340)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/handlers/patch.go:708 +0xa70
k8s.io/apiserver/pkg/endpoints/handlers.PatchResource.func1({0x408e790, 0xc00a1fc5e0}, 0xc00a27c780)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/handlers/patch.go:247 +0x27ff
k8s.io/apiserver/pkg/endpoints.(*APIInstaller).registerResourceHandlers.restfulPatchResource.func12(0xc00a1fc5c0, 0xc00a1e78f0)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/installer.go:1332 +0x62
k8s.io/apiserver/pkg/endpoints.(*APIInstaller).registerResourceHandlers.InstrumentRouteFunc.func13(0xc00a1fc5c0, 0xc00a1e78f0)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/metrics/metrics.go:645 +0x1c8
github.com/emicklei/go-restful/v3.(*Container).dispatch(0xc0063d4630, {0x40957a0, 0xc00a1e5680}, 0xc00a27c780)
    /home/runner/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.12.2/container.go:299 +0x9b7
github.com/emicklei/go-restful/v3.(*Container).Dispatch(...)
    /home/runner/go/pkg/mod/github.com/emicklei/go-restful/v3@v3.12.2/container.go:204
k8s.io/apiserver/pkg/server.director.ServeHTTP({{0x3ab524d?, 0x2308a1e?}, 0xc0063d4630?, 0xc000417f10?}, {0x40957a0, 0xc00a1e5680}, 0xc00a27c780)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/server/handler.go:145 +0x588
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.TrackCompleted.trackCompleted.func22({0x40957a0, 0xc00a1e5680}, 0xc00a27c780)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filterlatency/filterlatency.go:108 +0x138
net/http.HandlerFunc.ServeHTTP(0x4098748?, {0x40957a0?, 0xc00a1e5680?}, 0x4?)
    /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
k8s.io/apiserver/pkg/endpoints/filters.withAuthorization.func1({0x40957a0, 0xc00a1e5680}, 0xc00a27c780)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filters/authorization.go:84 +0x625
net/http.HandlerFunc.ServeHTTP(0x0?, {0x40957a0?, 0xc00a1e5680?}, 0x3ab5976?)
    /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1({0x40957a0, 0xc00a1e5680}, 0xc00a27c640)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filterlatency/filterlatency.go:93 +0x3f4
net/http.HandlerFunc.ServeHTTP(0x1c3442f?, {0x40957a0?, 0xc00a1e5680?}, 0x4055a58?)
    /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.TrackCompleted.trackCompleted.func23({0x40957a0, 0xc00a1e5680}, 0xc00a27c640)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filterlatency/filterlatency.go:108 +0x138
net/http.HandlerFunc.ServeHTTP(0xc00a1e5780?, {0x40957a0?, 0xc00a1e5680?}, 0x1de8070?)
    /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
k8s.io/apiserver/pkg/server/filters.(*priorityAndFairnessHandler).Handle.func10()
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/server/filters/priority-and-fairness.go:298 +0xd2
k8s.io/apiserver/pkg/util/flowcontrol.(*configController).Handle.func2()
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/util/flowcontrol/apf_filter.go:192 +0x21d
k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset.(*request).Finish.func1(0xc00a1ea4b0?, 0x70?, 0x393a4e0?)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go:391 +0x47
k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset.(*request).Finish(0xc00a1ea4b0, 0xc00a1e7880)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/util/flowcontrol/fairqueuing/queueset/queueset.go:392 +0x39
k8s.io/apiserver/pkg/util/flowcontrol.(*configController).Handle(0xc005e2e780, {0x40987f0, 0xc00a1e7500}, {0xc00a197520, {0x4099090, 0xc00a1e55c0}}, 0x38a1de0?, 0xc00d466a38?, 0x22ee8b7?, 0xc00a1e5740)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/util/flowcontrol/apf_filter.go:179 +0x76b
k8s.io/apiserver/pkg/server/filters.(*priorityAndFairnessHandler).Handle.func11(0xc0006bcaa0, {0x4098748?, 0xc00a24f4d0?}, {0xc00a197520?, {0x4099090?, 0xc00a1e55c0?}}, 0xc00a1fc560, 0xc00a24f500, 0xc00a1e9a60, 0xc00a1e5740)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/server/filters/priority-and-fairness.go:304 +0xea
k8s.io/apiserver/pkg/server/filters.(*priorityAndFairnessHandler).Handle(0xc0006bcaa0, {0x40957a0, 0xc00a1e5680}, 0xc00a27c640)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/server/filters/priority-and-fairness.go:305 +0x9f6
net/http.HandlerFunc.ServeHTTP(0x0?, {0x40957a0?, 0xc00a1e5680?}, 0x3ac6634?)
    /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1({0x40957a0, 0xc00a1e5680}, 0xc00a27c500)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filterlatency/filterlatency.go:93 +0x3f4
net/http.HandlerFunc.ServeHTTP(0x1c3442f?, {0x40957a0?, 0xc00a1e5680?}, 0x4055a58?)
    /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.TrackCompleted.trackCompleted.func24({0x40957a0, 0xc00a1e5680}, 0xc00a27c500)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filterlatency/filterlatency.go:108 +0x138
net/http.HandlerFunc.ServeHTTP(0xc00a24f140?, {0x40957a0?, 0xc00a1e5680?}, 0xc00a24f320?)
    /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithImpersonation.func4({0x40957a0, 0xc00a1e5680}, 0xc00a27c500)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filters/impersonation/impersonation.go:51 +0x1b0
net/http.HandlerFunc.ServeHTTP(0x0?, {0x40957a0?, 0xc00a1e5680?}, 0x3ab5983?)
    /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1({0x40957a0, 0xc00a1e5680}, 0xc00a27c3c0)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filterlatency/filterlatency.go:93 +0x3f4
net/http.HandlerFunc.ServeHTTP(0x1c3442f?, {0x40957a0?, 0xc00a1e5680?}, 0x4055a58?)
    /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.TrackCompleted.trackCompleted.func25({0x40957a0, 0xc00a1e5680}, 0xc00a27c3c0)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filterlatency/filterlatency.go:108 +0x138
net/http.HandlerFunc.ServeHTTP(0x465d91?, {0x40957a0?, 0xc00a1e5680?}, 0x3aa54a9?)
    /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1({0x40957a0, 0xc00a1e5680}, 0xc00a27c280)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filterlatency/filterlatency.go:93 +0x3f4
net/http.HandlerFunc.ServeHTTP(0x4098748?, {0x40957a0?, 0xc00a1e5680?}, 0x4055a58?)
    /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
k8s.io/apiserver/pkg/endpoints/filters.WithTracing.func2({0x40957a0, 0xc00a1e5680}, 0xc00a27c140)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filters/traces.go:62 +0x597
net/http.HandlerFunc.ServeHTTP(0x4098748?, {0x40957a0?, 0xc00a1e5680?}, 0x4055a58?)
    /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.(*middleware).serveHTTP(0xc0004fbb00, {0x408e790, 0xc00a1fc4a0}, 0xc00a279e00, {0x4066b40, 0xc006079290})
    /home/runner/go/pkg/mod/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.64.0/handler.go:178 +0x12c3
go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.NewMiddleware.func1.1({0x408e790?, 0xc00a1fc4a0?}, 0x17e0f?)
    /home/runner/go/pkg/mod/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp@v0.64.0/handler.go:66 +0x35
net/http.HandlerFunc.ServeHTTP(0x1c3442f?, {0x408e790?, 0xc00a1fc4a0?}, 0x4055a58?)
    /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.TrackCompleted.trackCompleted.func27({0x408e790, 0xc00a1fc4a0}, 0xc00a279e00)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filterlatency/filterlatency.go:108 +0x138
net/http.HandlerFunc.ServeHTTP(0x4098748?, {0x408e790?, 0xc00a1fc4a0?}, 0x404e8a0?)
    /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
k8s.io/apiserver/pkg/endpoints/filters.withAuthentication.func1({0x408e790, 0xc00a1fc4a0}, 0xc00a279e00)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filters/authentication.go:123 +0x87f
net/http.HandlerFunc.ServeHTTP(0x4098748?, {0x408e790?, 0xc00a1fc4a0?}, 0x4055a58?)
    /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
k8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1({0x408e790, 0xc00a1fc4a0}, 0xc00a279b80)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filterlatency/filterlatency.go:93 +0x3f4
net/http.HandlerFunc.ServeHTTP(0xc00a279900?, {0x408e790?, 0xc00a1fc4a0?}, 0xc009f45b80?)
    /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithWarningRecorder.func11({0x408e790, 0xc00a1fc4a0}, 0xc00a279900)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filters/warning.go:35 +0xb9
net/http.HandlerFunc.ServeHTTP(0xc007551c70?, {0x408e790?, 0xc00a1fc4a0?}, 0xc00c8cefd0?)
    /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
k8s.io/apiserver/pkg/server/filters.(*timeoutHandler).ServeHTTP.func1()
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/server/filters/timeout.go:115 +0x5b
created by k8s.io/apiserver/pkg/server/filters.(*timeoutHandler).ServeHTTP in goroutine 4649
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/server/filters/timeout.go:101 +0x198
 
goroutine 4649 [running]:
golang.org/x/net/http2.(*serverConn).runHandler.func1()
    /home/runner/go/pkg/mod/golang.org/x/net@v0.49.0/http2/server.go:2417 +0x145
panic({0x324e760?, 0xc009597da0?})
    /opt/hostedtoolcache/go/1.25.0/x64/src/runtime/panic.go:783 +0x132
k8s.io/apimachinery/pkg/util/runtime.handleCrash({0x4098710, 0x61746a0}, {0x324e760, 0xc009597da0}, {0xc007cb93b0, 0x1, 0x4c1931?})
    /home/runner/go/pkg/mod/k8s.io/apimachinery@v0.35.3/pkg/util/runtime/runtime.go:114 +0x1a9
k8s.io/apimachinery/pkg/util/runtime.HandleCrash({0xc007cb93f8, 0x1, 0xc005fe7340?})
    /home/runner/go/pkg/mod/k8s.io/apimachinery@v0.35.3/pkg/util/runtime/runtime.go:64 +0x17b
panic({0x324e760?, 0xc009597da0?})
    /opt/hostedtoolcache/go/1.25.0/x64/src/runtime/panic.go:783 +0x132
k8s.io/apiserver/pkg/server/filters.(*timeoutHandler).ServeHTTP(0xc006079368, {0x408e790, 0xc00a1fc440}, 0xdf8475800?)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/server/filters/timeout.go:121 +0x32f
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestDeadline.withRequestDeadline.func28({0x408e790, 0xc00a1fc440}, 0xc00a279680)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filters/request_deadline.go:100 +0x234
net/http.HandlerFunc.ServeHTTP(0x4098748?, {0x408e790?, 0xc00a1fc440?}, 0x10?)
    /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithWaitGroup.withWaitGroup.func29({0x408e790, 0xc00a1fc440}, 0xc00a279680)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/server/filters/waitgroup.go:86 +0x17d
net/http.HandlerFunc.ServeHTTP(0xc00a24edb0?, {0x408e790?, 0xc00a1fc440?}, 0x3ac00b1?)
    /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithCacheControl.func14({0x408e790, 0xc00a1fc440}, 0xc00a279680)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filters/cachecontrol.go:31 +0xa7
net/http.HandlerFunc.ServeHTTP(0x7f16d764a5c0?, {0x408e790?, 0xc00a1fc440?}, 0xc00a1fc440?)
    /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithHTTPLogging.WithLogging.withLogging.func35({0x408e790, 0xc00a1fc440}, 0xc00a279680)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/server/httplog/httplog.go:112 +0x94
net/http.HandlerFunc.ServeHTTP(0x4099100?, {0x408e790?, 0xc00a1fc440?}, 0xc005d16960?)
    /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithLatencyTrackers.func16({0x408d450, 0xc000013790}, 0xc00a279540)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filters/webhook_duration.go:56 +0x143
net/http.HandlerFunc.ServeHTTP(0xc00a279400?, {0x408d450?, 0xc000013790?}, 0x130?)
    /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x408d450, 0xc000013790}, 0xc00a279400)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filters/requestinfo.go:39 +0x119
net/http.HandlerFunc.ServeHTTP(0xc00a2792c0?, {0x408d450?, 0xc000013790?}, 0x19903c90bc?)
    /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x408d450, 0xc000013790}, 0xc00a2792c0)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filters/request_received_time.go:38 +0xaf
net/http.HandlerFunc.ServeHTTP(0xc000100008?, {0x408d450?, 0xc000013790?}, 0x47e8a5?)
    /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x408d450?, 0xc000013790?}, 0xc00a2792c0?)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xd5
net/http.HandlerFunc.ServeHTTP(0x0?, {0x408d450?, 0xc000013790?}, 0x8?)
    /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x408d450, 0xc000013790}, 0xc00a2792c0)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/server/filters/wrap.go:73 +0xdc
net/http.HandlerFunc.ServeHTTP(0xc00a24edb0?, {0x408d450?, 0xc000013790?}, 0xc00a8ea5d0?)
    /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
k8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x408d450, 0xc000013790}, 0xc00a279180)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/endpoints/filters/audit_init.go:63 +0x12d
net/http.HandlerFunc.ServeHTTP(0x0?, {0x408d450?, 0xc000013790?}, 0xc007e14090?)
    /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:2322 +0x29
k8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x6151040?, {0x408d450?, 0xc000013790?}, 0xc0000abf08?)
    /home/runner/go/pkg/mod/k8s.io/apiserver@v0.35.3/pkg/server/handler.go:188 +0x25
net/http.serverHandler.ServeHTTP({0xc0007deda0?}, {0x408d450?, 0xc000013790?}, 0xc0000abea0?)
    /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:3340 +0x8e
net/http.initALPNRequest.ServeHTTP({{0x4098748?, 0xc007dda390?}, 0xc007de0008?, {0xc007ae4f00?}}, {0x408d450, 0xc000013790}, 0xc00a279180)
    /opt/hostedtoolcache/go/1.25.0/x64/src/net/http/server.go:4013 +0x231
golang.org/x/net/http2.(*serverConn).runHandler(0x941388?, 0xc00a1ed080?, 0x0?, 0xc00a214ea0?)
    /home/runner/go/pkg/mod/golang.org/x/net@v0.49.0/http2/server.go:2424 +0x9d
created by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 541
    /home/runner/go/pkg/mod/golang.org/x/net@v0.49.0/http2/server.go:2359 +0x21f
{"time":"2026-04-28T08:22:53.874052409Z","level":"INFO","message":"strategy","logger":"sdc-api-server-logger","data":{"op":"Update New","key":{"Namespace":"default","Name":"intent2-sros"},"kind":"","resourceVersion":"8","generation":9,"managedFields":3,"finalizers":["configset.config.sdcio.dev/finalizer"]}}
{"time":"2026-04-28T08:22:53.874074833Z","level":"INFO","message":"strategy","logger":"sdc-api-server-logger","data":{"op":"Update Old","key":{"Namespace":"default","Name":"intent2-sros"},"kind":"","resourceVersion":"8","generation":8,"managedFields":3,"finalizers":["configset.config.sdcio.dev/finalizer"]}}